### PR TITLE
Add accessible title and lazy loading to form iframe

### DIFF
--- a/index.html
+++ b/index.html
@@ -163,7 +163,7 @@
           <div style="height:18px"></div>
           <!-- TODO: Reemplaza el src con el formulario de producción -->
           <!-- Microsoft Forms embed: replace the src with your production form link -->
-          <iframe src="https://forms.office.com/r/2xx9fx1j4x?origin=lprLink&embed=true" style="width:100%;height:420px;border:1px solid var(--ink-200);border-radius:12px" allowfullscreen webkitallowfullscreen mozallowfullscreen></iframe>
+          <iframe src="https://forms.office.com/r/2xx9fx1j4x?origin=lprLink&embed=true" title="Formulario de diagnóstico para guía gratuita" loading="lazy" style="width:100%;height:420px;border:1px solid var(--ink-200);border-radius:12px" allowfullscreen webkitallowfullscreen mozallowfullscreen></iframe>
           <p style="font-size:13px;color:var(--ink-500);margin-top:8px">Completa el formulario para recibir tu guía. Si el formulario no carga, <a href="https://forms.office.com/r/2xx9fx1j4x?origin=lprLink" target="_blank" rel="noopener">haz clic aquí</a>.</p>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- add descriptive title and lazy loading to embedded Microsoft Forms iframe for better accessibility and performance

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689990c6ceac832ca20f283b1f41db06