### PR TITLE
feat: enhance mobile menu accessibility

### DIFF
--- a/main.js
+++ b/main.js
@@ -3,9 +3,38 @@
 document.addEventListener('DOMContentLoaded', () => {
   const navToggle = document.querySelector('[data-nav-toggle]');
   const menu = document.querySelector('[data-nav-menu]');
-  if(navToggle && menu){
-    navToggle.addEventListener('click', () => {
-      menu.classList.toggle('open');
+  if (navToggle && menu) {
+    // Ensure aria-expanded is set for accessibility
+    navToggle.setAttribute('aria-expanded', 'false');
+
+    const closeMenu = () => {
+      menu.classList.remove('open');
+      navToggle.setAttribute('aria-expanded', 'false');
+    };
+
+    const toggleMenu = () => {
+      const isOpen = menu.classList.toggle('open');
+      navToggle.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+    };
+
+    navToggle.addEventListener('click', toggleMenu);
+
+    // Close menu when a link inside is clicked
+    menu.addEventListener('click', (e) => {
+      if (e.target.closest('a')) {
+        closeMenu();
+      }
+    });
+
+    // Close menu when focus moves outside of toggle or menu
+    document.addEventListener('focusin', (e) => {
+      if (
+        menu.classList.contains('open') &&
+        !menu.contains(e.target) &&
+        !navToggle.contains(e.target)
+      ) {
+        closeMenu();
+      }
     });
   }
 


### PR DESCRIPTION
## Summary
- toggle `aria-expanded` on nav toggle button
- close mobile menu on link clicks or when focus moves outside

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689990c7e33c832c8d3e1d3045fb5ecd