### PR TITLE
chore: move mobile menu styles to stylesheet

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,20 +40,6 @@
         y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
     })(window, document, "clarity", "script", "ssesjal0pd");
   </script>
-  <style>
-    /* Minimal mobile menu for demo */
-    .menu{display:flex;gap:8px;align-items:center}
-    .menu a{opacity:.9}
-    .menu .open{display:block}
-    @media(max-width:920px){
-      .menu{display:none;position:absolute;top:64px;right:12px;background:var(--ink-0);border:1px solid var(--ink-100);border-radius:12px;padding:12px;box-shadow:var(--shadow)}
-      .menu.open{display:flex;flex-direction:column;min-width:200px}
-      .nav-inner button{display:inline-flex}
-    }
-    @media(min-width:921px){
-      .nav-inner button{display:none}
-    }
-  </style>
 </head>
 <body>
   <!-- Google Tag Manager (noscript) -->

--- a/styles.css
+++ b/styles.css
@@ -74,6 +74,19 @@ img{max-width:100%;display:block}
 }
 .nav-cta:hover{filter:brightness(0.95)}
 
+/* Minimal mobile menu for demo */
+.menu{display:flex;gap:8px;align-items:center}
+.menu a{opacity:.9}
+.menu .open{display:block}
+@media(max-width:920px){
+  .menu{display:none;position:absolute;top:64px;right:12px;background:var(--ink-0);border:1px solid var(--ink-100);border-radius:12px;padding:12px;box-shadow:var(--shadow)}
+  .menu.open{display:flex;flex-direction:column;min-width:200px}
+  .nav-inner button{display:inline-flex}
+}
+@media(min-width:921px){
+  .nav-inner button{display:none}
+}
+
 /* Hero */
 .hero{
   padding:96px 0 48px;


### PR DESCRIPTION
## Summary
- move inline menu styles into `styles.css`
- remove redundant `<style>` block from `index.html`

## Testing
- `npm test` *(fails: no such file or directory, package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689990ccc888832c93ff9b666232f429