### PR TITLE
Use SVG logo for favicon and Open Graph image

### DIFF
--- a/img/logo.svg
+++ b/img/logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="32" viewBox="0 0 360 96">
+    <rect width="360" height="96" rx="12" fill="#0A0A0B"/>
+    <text x="24" y="62" font-family="Segoe UI, Inter, system-ui, -apple-system, Roboto, Arial, sans-serif" font-size="48" font-weight="700" fill="#19C37D">Simiriki</text>
+    </svg>

--- a/index.html
+++ b/index.html
@@ -5,12 +5,12 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Simiriki — Automatiza. Escala. Transforma.</title>
   <meta name="description" content="Consultoría y automatización con IA en Microsoft. Implementamos chatbots, flujos y funnels que venden 24/7.">
-  <link rel="icon" type="image/png" href="img/icon.png">
+  <link rel="icon" type="image/svg+xml" href="/img/logo.svg">
   <meta property="og:title" content="Simiriki — Automatiza. Escala. Transforma.">
   <meta property="og:description" content="Implementamos IA y flujos en Microsoft para que tu negocio venda sin contestar mensajes.">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://www.simiriki.com/">
-  <meta property="og:image" content="https://www.simiriki.comimg/icon.png">
+  <meta property="og:image" content="https://www.simiriki.com/img/logo.svg">
   <meta name="twitter:card" content="summary_large_image">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <!-- Optional Google Font (Inter). Safe fallbacks are used if blocked. -->


### PR DESCRIPTION
## Summary
- replace binary `icon.png` with text-based `img/logo.svg`
- update favicon link to `/img/logo.svg`
- fix Open Graph image URL to `https://www.simiriki.com/img/logo.svg`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689990be27f8832ca3ea8f82c66f855c