### PR TITLE
Add legal pages and update branding

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,7 +14,9 @@
   </head>
   <body>
     <header class="navbar">
-      <a href="#inicio" class="logo">Simiriki</a>
+      <a href="#inicio" class="logo">
+        <img src="logo.svg" alt="Simiriki logo" />
+      </a>
       <button class="nav-toggle" aria-label="Abrir menú" data-nav-toggle>
         ☰
       </button>
@@ -127,6 +129,10 @@
 
     <footer class="footer">
       <p>© 2025 Simiriki. Todos los derechos reservados.</p>
+      <nav class="footer-links">
+        <a href="privacy.html">Política de Privacidad</a>
+        <a href="terms.html">Términos de Servicio</a>
+      </nav>
     </footer>
 
     <script src="script.js" defer></script>

--- a/logo.svg
+++ b/logo.svg
@@ -1,4 +1,11 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="120" height="32" viewBox="0 0 360 96">
-    <rect width="360" height="96" rx="12" fill="#0A0A0B"/>
-    <text x="24" y="62" font-family="Segoe UI, Inter, system-ui, -apple-system, Roboto, Arial, sans-serif" font-size="48" font-weight="700" fill="#19C37D">Simiriki</text>
-    </svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 220 48">
+  <defs>
+    <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#6366F1"/>
+      <stop offset="100%" stop-color="#22D3EE"/>
+    </linearGradient>
+  </defs>
+  <rect width="48" height="48" rx="12" fill="url(#grad)"/>
+  <path d="M24 14c-4 0-7 3-7 6 0 2 1 4 4 5l3 1c3 1 4 2 4 4 0 3-2 5-6 5s-6-2-6-5" fill="none" stroke="#ffffff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+  <text x="60" y="32" font-family="Inter, 'Segoe UI', sans-serif" font-size="28" font-weight="700" fill="#0f172a">Simiriki</text>
+</svg>

--- a/privacy.html
+++ b/privacy.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Política de Privacidad - Simiriki</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header class="navbar">
+      <a href="index.html" class="logo">
+        <img src="logo.svg" alt="Simiriki logo" />
+      </a>
+    </header>
+    <main class="legal-page">
+      <h1>Política de Privacidad</h1>
+      <p>
+        En Simiriki, respetamos tu privacidad. Esta página describe cómo recopilamos,
+        usamos y protegemos tu información personal.
+      </p>
+    </main>
+    <footer class="footer">
+      <p>© 2025 Simiriki. Todos los derechos reservados.</p>
+      <nav class="footer-links">
+        <a href="privacy.html">Política de Privacidad</a>
+        <a href="terms.html">Términos de Servicio</a>
+      </nav>
+    </footer>
+  </body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -43,6 +43,13 @@ a {
 .logo {
   font-weight: 700;
   font-size: 1.2rem;
+  display: inline-flex;
+  align-items: center;
+}
+
+.logo img {
+  height: 32px;
+  display: block;
 }
 .nav-menu {
   display: flex;
@@ -251,4 +258,24 @@ a {
   text-align: center;
   padding: 1.5rem;
   font-size: 0.9rem;
+}
+
+.footer-links {
+  margin-top: 0.5rem;
+}
+
+.footer-links a {
+  margin: 0 0.5rem;
+  color: #fff;
+  text-decoration: underline;
+}
+
+.legal-page {
+  padding: 6rem 2rem 4rem;
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+.legal-page h1 {
+  margin-top: 0;
 }

--- a/terms.html
+++ b/terms.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Términos de Servicio - Simiriki</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header class="navbar">
+      <a href="index.html" class="logo">
+        <img src="logo.svg" alt="Simiriki logo" />
+      </a>
+    </header>
+    <main class="legal-page">
+      <h1>Términos de Servicio</h1>
+      <p>
+        Estos términos rigen el uso de Simiriki. Al utilizar nuestros servicios
+        aceptas estas condiciones.
+      </p>
+    </main>
+    <footer class="footer">
+      <p>© 2025 Simiriki. Todos los derechos reservados.</p>
+      <nav class="footer-links">
+        <a href="privacy.html">Política de Privacidad</a>
+        <a href="terms.html">Términos de Servicio</a>
+      </nav>
+    </footer>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- replace temporary logo with final gradient version
- add privacy policy and terms of service pages and link them in footer
- style footer links and legal pages

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899a49035d8832c8d99b35f085d3882