### PR TITLE
ci(swa): use repo-relative app_location

### DIFF
--- a/.github/workflows/deploy-swa.yml
+++ b/.github/workflows/deploy-swa.yml
@@ -47,5 +47,5 @@ jobs:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN }}
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           action: upload
-          app_location: /
+          app_location: .
           skip_app_build: true


### PR DESCRIPTION
Fix P0: Static Web Apps deploy was using app_location: '/' which resolves to the container root in the GitHub runner. Set to '.' so the action packages the repository content as intended.\n\n- action: upload\n- app_location: '.'\n- skip_app_build: true\n\nNo other changes.